### PR TITLE
Add powerups

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -4,6 +4,7 @@
 #include "src/classes/CombatManager.h"
 #include "src/classes/Hostile.h"
 #include "src/classes/FollowCam.h"
+#include "src/classes/PowerUp.h"
 #include "src/classes/TrainEngine.h"
 #include "src/classes/TrainCar.h"
 #include "src/classes/UIManager.h"
@@ -74,6 +75,8 @@ int main(void)
     _assets.loadTexture("assets/textures/missile1_albedo.png", "missile1");
     _assets.loadSound("assets/sounds/missile_fire.wav", "missile_fire");
 
+    PowerUp pup(_assets.getModel("duck"), _assets.getTexture("duck"), PowerUpType::HealthPack, 20);
+
     TrainEngine engine(_assets.getModel("duck"), _assets.getTexture("duck"), 10.f, 80.f, 20.f, 2.5f);
 
     TrainCar carriage(
@@ -133,6 +136,7 @@ int main(void)
             train.update(deltaTime);
             followCam.update(deltaTime);
             combatManager.update(deltaTime);
+            pup.update(deltaTime);
         }
 
         if (_gameStateManager.getState() == GameState::Gameplay || _gameStateManager.getState() == GameState::Paused) {
@@ -143,6 +147,7 @@ int main(void)
             train.draw();
             followCam.draw();
             combatManager.draw();
+            pup.draw();
             DrawGrid(2000, 20.f);
             EndMode3D();
 

--- a/main.cpp
+++ b/main.cpp
@@ -75,8 +75,6 @@ int main(void)
     _assets.loadTexture("assets/textures/missile1_albedo.png", "missile1");
     _assets.loadSound("assets/sounds/missile_fire.wav", "missile_fire");
 
-    PowerUp pup({200.f, 0.f, 0.f}, _assets.getModel("duck"), _assets.getTexture("duck"), PowerUpType::HealthPack, 20);
-
     TrainEngine engine(_assets.getModel("duck"), _assets.getTexture("duck"), 10.f, 80.f, 20.f, 2.5f);
 
     TrainCar carriage(
@@ -136,7 +134,6 @@ int main(void)
             train.update(deltaTime);
             followCam.update(deltaTime);
             combatManager.update(deltaTime);
-            pup.update(deltaTime);
         }
 
         if (_gameStateManager.getState() == GameState::Gameplay || _gameStateManager.getState() == GameState::Paused) {
@@ -147,7 +144,6 @@ int main(void)
             train.draw();
             followCam.draw();
             combatManager.draw();
-            pup.draw();
             DrawGrid(2000, 20.f);
             EndMode3D();
 

--- a/main.cpp
+++ b/main.cpp
@@ -75,7 +75,7 @@ int main(void)
     _assets.loadTexture("assets/textures/missile1_albedo.png", "missile1");
     _assets.loadSound("assets/sounds/missile_fire.wav", "missile_fire");
 
-    PowerUp pup(_assets.getModel("duck"), _assets.getTexture("duck"), PowerUpType::HealthPack, 20);
+    PowerUp pup({200.f, 0.f, 0.f}, _assets.getModel("duck"), _assets.getTexture("duck"), PowerUpType::HealthPack, 20);
 
     TrainEngine engine(_assets.getModel("duck"), _assets.getTexture("duck"), 10.f, 80.f, 20.f, 2.5f);
 

--- a/src/classes/CombatManager.cpp
+++ b/src/classes/CombatManager.cpp
@@ -26,6 +26,17 @@ CombatManager::CombatManager(FollowCam* camera, Train* train, ScoreManager* scor
     );
 
     this->hostileTypes.push_back(hostile);
+
+    // Define the different PowerUps the CombatManager can spawn
+    PowerUp healthPackSmall(
+        {0.f, 0.f, 0.f},
+        _assets.getModel("duck"),
+        _assets.getTexture("duck"),
+        PowerUpType::HealthPack,
+        10
+    );
+
+    this->powerupTypes.push_back(healthPackSmall);
 }
 
 Train* CombatManager::getTrain() {
@@ -105,6 +116,20 @@ void CombatManager::spawnHostile() {
     this->projectiles[h] = std::vector<Projectile*>();
 }
 
+void CombatManager::spawnPowerup(Vector3 pos) {
+    // TODO: When there's more than 1 powerup, randomize which one gets spawned
+
+    PowerUp* p = new PowerUp(
+        pos,
+        *this->powerupTypes[0].getModel(),
+        *this->powerupTypes[0].getTexture(),
+        this->powerupTypes[0].getType(),
+        this->powerupTypes[0].getMagnitude()
+    );
+
+    this->powerups.push_back(p);
+}
+
 void CombatManager::update(float deltaTime) {
     if (this->hostiles.size() == 0) {
         this->spawnHostile();
@@ -150,6 +175,8 @@ void CombatManager::update(float deltaTime) {
             this->camera->unsetTarget();
             this->camera->parent = this->train->resetActiveComponent();
             this->camera->resetmouseRotationAdjustment();
+
+            this->spawnPowerup((*hostileIt)->position);
 
             delete (*hostileIt);
             hostileIt = this->hostiles.erase(hostileIt);

--- a/src/classes/CombatManager.cpp
+++ b/src/classes/CombatManager.cpp
@@ -212,6 +212,23 @@ void CombatManager::update(float deltaTime) {
         }
     }
     
+    // Update any projectiles targeted at the player
+    std::vector<PowerUp*>::iterator powerUpIt = this->powerups.begin();
+
+    while (powerUpIt != this->powerups.end()) {
+        // Update the powerup
+        (*powerUpIt)->update(deltaTime);
+
+        // If the powerup is not alive after updating, give the train its bonus and then delete it from the heap
+        if (!(*powerUpIt)->getIsAlive()) {
+            this->train->receivePowerUp((*powerUpIt));
+            delete (*powerUpIt);
+            powerUpIt = this->powerups.erase(powerUpIt);
+        }
+        else {
+            ++powerUpIt;
+        }
+    }
 
     Ray targetRay = this->getTargetingRay();
 
@@ -243,6 +260,11 @@ void CombatManager::draw() {
 
     // Draw any projectiles targeted at the player
     for (std::vector<Projectile*>::iterator it = this->projectiles[this->train].begin(); it != this->projectiles[this->train].end(); ++it) {
+        (*it)->draw();
+    }
+
+    // Draw powerups
+    for (std::vector<PowerUp*>::iterator it = this->powerups.begin(); it != this->powerups.end(); ++it) {
         (*it)->draw();
     }
     

--- a/src/classes/CombatManager.cpp
+++ b/src/classes/CombatManager.cpp
@@ -221,7 +221,7 @@ void CombatManager::update(float deltaTime) {
 
         // If the powerup is not alive after updating, give the train its bonus and then delete it from the heap
         if (!(*powerUpIt)->getIsAlive()) {
-            this->train->receivePowerUp((*powerUpIt));
+            this->train->receivePowerUp(*powerUpIt);
             delete (*powerUpIt);
             powerUpIt = this->powerups.erase(powerUpIt);
         }

--- a/src/classes/CombatManager.cpp
+++ b/src/classes/CombatManager.cpp
@@ -219,6 +219,12 @@ void CombatManager::update(float deltaTime) {
         // Update the powerup
         (*powerUpIt)->update(deltaTime);
 
+        // Check if the powerup is colliding with the player
+
+        if (CheckCollisionBoxes(this->train->head()->getBounds(), (*powerUpIt)->getBounds())) {
+            (*powerUpIt)->setIsAlive(false);
+        }
+
         // If the powerup is not alive after updating, give the train its bonus and then delete it from the heap
         if (!(*powerUpIt)->getIsAlive()) {
             this->train->receivePowerUp(*powerUpIt);

--- a/src/classes/CombatManager.h
+++ b/src/classes/CombatManager.h
@@ -5,6 +5,7 @@
 #include "ScoreManager.h"
 #include "src/classes/FollowCam.h"
 #include "src/classes/Hostile.h"
+#include "src/classes/PowerUp.h"
 #include "src/interfaces/ICombatant.h"
 #include "src/interfaces/IUpdatable.h"
 #include "src/classes/Train.h"
@@ -26,6 +27,9 @@ private:
     // Types of Hostiles the CombatManager can spawn
     std::vector<Hostile> hostileTypes;
 
+    // Types of PowerUp the CombatManager can spawn
+    std::vector<PowerUp> powerupTypes;
+
     // ==================================================
     // Targeting member variables
     // ==================================================
@@ -46,7 +50,11 @@ private:
     std::map<ICombatant*, std::vector<Projectile*>> projectiles;
     Train* train;
 
+    std::vector<PowerUp*> powerups;
+
     void spawnHostile();
+
+    void spawnPowerup(Vector3 pos);
 
 public:
     /**

--- a/src/classes/PowerUp.cpp
+++ b/src/classes/PowerUp.cpp
@@ -5,10 +5,10 @@ PowerUp::PowerUp(PowerUpType type, int magnitude) {
     this->magnitude = magnitude;
 }
 
-void PowerUp::update() {
+void PowerUp::update(float deltaTime) {
     
 }
 
-void PowerUp::draw(float deltaTime) {
+void PowerUp::draw() {
 
 }

--- a/src/classes/PowerUp.cpp
+++ b/src/classes/PowerUp.cpp
@@ -1,7 +1,7 @@
 #include "PowerUp.h"
 
-PowerUp::PowerUp(Model model, Texture2D texture, PowerUpType type, int magnitude)
-: Actor({0.f, 0.f, 0.f}, model, texture) {
+PowerUp::PowerUp(Vector3 position, Model model, Texture2D texture, PowerUpType type, int magnitude)
+: Actor(position, model, texture) {
     this->type = type;
     this->magnitude = magnitude;
 }

--- a/src/classes/PowerUp.cpp
+++ b/src/classes/PowerUp.cpp
@@ -1,14 +1,18 @@
 #include "PowerUp.h"
 
-PowerUp::PowerUp(PowerUpType type, int magnitude) {
+PowerUp::PowerUp(Model model, Texture2D texture, PowerUpType type, int magnitude)
+: Actor({0.f, 0.f, 0.f}, model, texture) {
     this->type = type;
     this->magnitude = magnitude;
 }
 
 void PowerUp::update(float deltaTime) {
-    
+
+    this->rotateBy( Vector3Scale({0.f, this->rotationDirection == Direction::Right ? -1.5f : 1.5f, 0.f}, deltaTime));
+
+    Actor::update();    
 }
 
 void PowerUp::draw() {
-
+    Actor::draw();
 }

--- a/src/classes/PowerUp.cpp
+++ b/src/classes/PowerUp.cpp
@@ -6,6 +6,14 @@ PowerUp::PowerUp(Vector3 position, Model model, Texture2D texture, PowerUpType t
     this->magnitude = magnitude;
 }
 
+PowerUpType PowerUp::getType() {
+    return this->type;
+}
+
+int PowerUp::getMagnitude() {
+    return this->magnitude;
+}
+
 void PowerUp::update(float deltaTime) {
 
     this->rotateBy( Vector3Scale({0.f, this->rotationDirection == Direction::Right ? -1.5f : 1.5f, 0.f}, deltaTime));

--- a/src/classes/PowerUp.cpp
+++ b/src/classes/PowerUp.cpp
@@ -14,6 +14,14 @@ int PowerUp::getMagnitude() {
     return this->magnitude;
 }
 
+bool PowerUp::getIsAlive() {
+    return this->isAlive;
+}
+
+void PowerUp::setIsAlive(bool value) {
+    this->isAlive = value;
+}
+
 void PowerUp::update(float deltaTime) {
 
     this->rotateBy( Vector3Scale({0.f, this->rotationDirection == Direction::Right ? -1.5f : 1.5f, 0.f}, deltaTime));

--- a/src/classes/PowerUp.cpp
+++ b/src/classes/PowerUp.cpp
@@ -1,0 +1,14 @@
+#include "PowerUp.h"
+
+PowerUp::PowerUp(PowerUpType type, int magnitude) {
+    this->type = type;
+    this->magnitude = magnitude;
+}
+
+void PowerUp::update() {
+    
+}
+
+void PowerUp::draw(float deltaTime) {
+
+}

--- a/src/classes/PowerUp.h
+++ b/src/classes/PowerUp.h
@@ -19,6 +19,9 @@ public:
 
     PowerUp(Vector3 position, Model model, Texture2D texture, PowerUpType type, int magnitude);
 
+    PowerUpType getType();
+    int getMagnitude();
+
    void update(float deltaTime);
 
    void draw();

--- a/src/classes/PowerUp.h
+++ b/src/classes/PowerUp.h
@@ -17,7 +17,7 @@ private:
 
 public:
 
-    PowerUp(PowerUpType type, int magnitude);
+    PowerUp(Model model, Texture2D texture, PowerUpType type, int magnitude);
 
    void update(float deltaTime);
 

--- a/src/classes/PowerUp.h
+++ b/src/classes/PowerUp.h
@@ -19,8 +19,8 @@ public:
 
     PowerUp(PowerUpType type, int magnitude);
 
-   void update();
+   void update(float deltaTime);
 
-   void draw(float deltaTime);
+   void draw();
 
 };

--- a/src/classes/PowerUp.h
+++ b/src/classes/PowerUp.h
@@ -17,7 +17,7 @@ private:
 
 public:
 
-    PowerUp(Model model, Texture2D texture, PowerUpType type, int magnitude);
+    PowerUp(Vector3 position, Model model, Texture2D texture, PowerUpType type, int magnitude);
 
    void update(float deltaTime);
 

--- a/src/classes/PowerUp.h
+++ b/src/classes/PowerUp.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "Actor.h"
+#include "src/enums/Direction.h"
+#include "src/enums/PowerUpType.h"
+
+class PowerUp: public Actor {
+private:
+
+    // The type of powerup
+    PowerUpType type;
+
+    // The magnitude of the bonus granted. e.g. A powerup of type HealthPack with magnitude 50 will restore 50 health
+    int magnitude;
+
+    Direction rotationDirection = Direction::Right;
+
+public:
+
+    PowerUp(PowerUpType type, int magnitude);
+
+   void update();
+
+   void draw(float deltaTime);
+
+};

--- a/src/classes/PowerUp.h
+++ b/src/classes/PowerUp.h
@@ -13,6 +13,8 @@ private:
     // The magnitude of the bonus granted. e.g. A powerup of type HealthPack with magnitude 50 will restore 50 health
     int magnitude;
 
+    bool isAlive = true;
+
     Direction rotationDirection = Direction::Right;
 
 public:
@@ -21,9 +23,12 @@ public:
 
     PowerUpType getType();
     int getMagnitude();
+    bool getIsAlive();
 
-   void update(float deltaTime);
+    void setIsAlive(bool value);
+    
+    void update(float deltaTime);
 
-   void draw();
+    void draw();
 
 };

--- a/src/classes/Train.cpp
+++ b/src/classes/Train.cpp
@@ -93,3 +93,20 @@ int Train::receiveDamage(int damageReceived) {
 
     return currentHitpoints;
 }
+
+void Train::receivePowerUp(PowerUp* pup) {
+    switch (pup->getType()) {
+        case PowerUpType::HealthPack:
+            if (this->currentHitpoints + pup->getMagnitude() > this->maxHitpoints) {
+                this->currentHitpoints += pup->getMagnitude();
+            } else {
+                this->currentHitpoints = this->maxHitpoints;
+            }
+            break;
+        case PowerUpType::SpeedBoost:
+            this->head()->topSpeed += pup->getMagnitude();
+            break;
+        default:
+            break;
+    }
+}

--- a/src/classes/Train.cpp
+++ b/src/classes/Train.cpp
@@ -97,10 +97,10 @@ int Train::receiveDamage(int damageReceived) {
 void Train::receivePowerUp(PowerUp* pup) {
     switch (pup->getType()) {
         case PowerUpType::HealthPack:
-            if (this->currentHitpoints + pup->getMagnitude() > this->maxHitpoints) {
-                this->currentHitpoints += pup->getMagnitude();
-            } else {
+            if (this->currentHitpoints + pup->getMagnitude() >= this->maxHitpoints) {
                 this->currentHitpoints = this->maxHitpoints;
+            } else {
+                this->currentHitpoints += pup->getMagnitude();
             }
             break;
         case PowerUpType::SpeedBoost:

--- a/src/classes/Train.h
+++ b/src/classes/Train.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "PowerUp.h"
 #include "Projectile.h"
 #include "TrainEngine.h"
 #include "TrainCar.h"
@@ -123,4 +124,10 @@ public:
      * @return  Returns hitpoints after damage is applied
     */
     int receiveDamage(int damageReceived);
+
+    /**
+     * Applies the given powerup to the Train
+     * @param pup   The PowerUp to apply to the Train
+    */
+    void receivePowerUp(PowerUp* pup);
 };

--- a/src/classes/TrainEngine.h
+++ b/src/classes/TrainEngine.h
@@ -1,7 +1,6 @@
 #pragma once
 #include "TrainComponent.h"
 #include "src/enums/Direction.h"
-#include "src/enums/Direction.h"
 #include "src/interfaces/IKeyboardListener.h"
 
 /**

--- a/src/enums/PowerUpType.h
+++ b/src/enums/PowerUpType.h
@@ -1,0 +1,10 @@
+#pragma once
+
+/**
+ * Types of powerups
+*/
+enum class PowerUpType{
+    SpeedBoost,
+    HealthPack,
+    ReloadSpeedBoost
+};


### PR DESCRIPTION
Add powerups which spawn when a Hostile dies.

Powerups come in a few types, but only 2 are supported currently and only 1 will ever spawn.
Powerups are handled by the CombatManager and can be collected by colliding with them