### PR TITLE
Handle parent rotation in train cars

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -49,30 +49,31 @@ int main(void)
         2.5f                                    // Rotation rate
     );
 
+    // Model model, Texture2D texture, TrainComponent* engine, float followDist, int power, int reloadTime, Model projectileModel, Texture2D projectiletexture, const char* projectileLaunchSFX, const char* projectileDestroySFX
     TrainCar carriage1(
-        _assets.getModel("train_wagon"),
-        _assets.getTexture("wagon"),
-        &engine,
-        6.f,
-        20,
-        3000,
-        _assets.getModel("missile"),
-        _assets.getTexture("missile"),
-        "missile_fire",
-        "explosion"
+        _assets.getModel("train_wagon"),        // Model
+        _assets.getTexture("wagon"),            // Texture
+        &engine,                                // Pointer to "parent" TrainComponent
+        6.f,                                    // Follow distance - how close this component gets to its parent
+        20,                                     // Power - How much damage this TrainCar deals
+        3000,                                   // ReloadTime (milliseconds)
+        _assets.getModel("missile"),            // Model used by projectiles fired by this TrainCar
+        _assets.getTexture("missile"),          // Texture used by projectiles fired by this TrainCar
+        "missile_fire",                         // Name of the sound to play when this TrainCar fires a projectile
+        "explosion"                             // Name of the sound to play when a projectile fired by this TrainCar is destroyed
     );
 
-    TrainCar carriage2(
-        _assets.getModel("train_wagon"),
-        _assets.getTexture("wagon"),
-        &carriage1,
-        10.5f,
-        5,
-        200,
-        _assets.getModel("bullet"),
-        _assets.getTexture("bullet"),
-        "bullet_fire",
-        "laser_hit"
+    TrainCar carriage2(                         
+        _assets.getModel("train_wagon"),        // Model
+        _assets.getTexture("wagon"),            // Texture
+        &carriage1,                             // Pointer to "parent" TrainComponent
+        10.5f,                                  // Follow distance - how close this component gets to its parent
+        5,                                      // Power - How much damage this TrainCar deals
+        200,                                    // ReloadTime (milliseconds)
+        _assets.getModel("bullet"),             // Model used by projectiles fired by this TrainCar
+        _assets.getTexture("bullet"),           // Texture used by projectiles fired by this TrainCar
+        "bullet_fire",                          // Name of the sound to play when this TrainCar fires a projectile
+        "laser_hit"                             // Name of the sound to play when a projectile fired by this TrainCar is destroyed
     );
 
     Train train({&engine, &carriage1, &carriage2}, 100); // The player character

--- a/main.cpp
+++ b/main.cpp
@@ -75,7 +75,6 @@ int main(void)
         "laser_hit"
     );
 
-    // Train train({&engine, &carriage1, &carriage2}, 100); // The player character
     Train train({&engine, &carriage1, &carriage2}, 100); // The player character
 
     // Create a parallax background

--- a/main.cpp
+++ b/main.cpp
@@ -76,7 +76,7 @@ int main(void)
     );
 
     // Train train({&engine, &carriage1, &carriage2}, 100); // The player character
-    Train train({&engine, &carriage1}, 100); // The player character
+    Train train({&engine, &carriage1, &carriage2}, 100); // The player character
 
     // Create a parallax background
     ParallaxBackground background(&train.head()->position, 2, _assets.getTextureRef("galaxy"));

--- a/main.cpp
+++ b/main.cpp
@@ -53,7 +53,7 @@ int main(void)
         _assets.getModel("train_wagon"),
         _assets.getTexture("wagon"),
         &engine,
-        12.f,
+        6.f,
         20,
         3000,
         _assets.getModel("missile"),
@@ -75,7 +75,8 @@ int main(void)
         "laser_hit"
     );
 
-    Train train({&engine, &carriage1, &carriage2}, 100); // The player character
+    // Train train({&engine, &carriage1, &carriage2}, 100); // The player character
+    Train train({&engine, &carriage1}, 100); // The player character
 
     // Create a parallax background
     ParallaxBackground background(&train.head()->position, 2, _assets.getTextureRef("galaxy"));

--- a/src/classes/TrainCar.cpp
+++ b/src/classes/TrainCar.cpp
@@ -30,10 +30,9 @@ void TrainCar::update(float deltaTime) {
    Vector3* parentAnchor = this->engine->getRearAttachmentPoint();
 
     // Update the train car to be pointing towards and following the TrainComponent assigned to the engine parameter
-    // Vector3 directionToParent = this->getVectorTowardTarget(this->engine->position);
     Vector3 directionToParent = this->getVectorTowardTarget(*parentAnchor);
-    Vector3 scaledInvertedPulledDirection = Vector3Scale(Vector3Negate(directionToParent), this->followDistance);
-    this->position = Vector3Add(*parentAnchor, scaledInvertedPulledDirection);
+    Vector3 followPosition = Vector3Scale(Vector3Negate(directionToParent), this->followDistance); // The position the TrainComponent needs to be at to follow its parent at followDistance
+    this->position = Vector3Add(*parentAnchor, followPosition);
     this->setRotation({0, this->angleToVector(*parentAnchor), 0});
 
     // Calculate how long is left until this car can shoot again

--- a/src/classes/TrainCar.cpp
+++ b/src/classes/TrainCar.cpp
@@ -19,60 +19,15 @@ TrainCar::TrainCar(Model model, Texture2D texture, TrainComponent* engine, float
     this->position = Vector3Add(*this->engine->getRearAttachmentPoint(), Vector3Scale(engineBack, this->followDistance));
 }
 
-// https://gamedev.stackexchange.com/a/18998
-bool isInFront(Vector3* point, Vector3* planeOrigin, Vector3 planeForward)
-{
-    double product = (point->x - planeOrigin->x) * planeForward.x
-                     + (point->y - planeOrigin->y) * planeForward.y
-                     + (point->z - planeOrigin->z) * planeForward.z;
-    return (product > 0.f);
-}
-
 /**
  * Update method
  * @param deltaTime Time in seconds for last frame drawn
 */
 void TrainCar::update(float deltaTime) {
     this->rearAttachmentPoint = Vector3Subtract(this->position, Vector3Scale(this->getForwardVector(), 2.f));
-    // Thinking up a new way of handling the rotation/position update
-    // Current solution works but allows TrainEngine to rotate freely without impacting cars behind it
-
-    /**
-     * Proposed new solution:
-     * 1. Calculate the rear anchor point of parent
-     * 2. Rotate self to face that rear anchor point
-     * 3. New position should be calculated based on new rotation + followDistance
-     * 4. Define a plane based on rear anchor point + parent forward vector
-     * 5. If my position is positive on that plane;
-     *  5a. Push me in the opposite direction of my parent's forward vector
-     *  5b. Repeat steps 2-5 until 5 is false
-     * 6. New position found
-    */ 
 
    // Get rear attachment point of parent
    Vector3* parentAnchor = this->engine->getRearAttachmentPoint();
-
-   // Calculate what my rotation would need to be to face that
-//    float potentialRotation = this->angleToVector(this->engine->position);
-
-   // While I am in the positive of a plane described by my parent's forward vector and anchor point, push me back
-//    while (isInFront(&this->position, parentAnchor, this->engine->getForwardVector())) {
-//     this->position = Vector3Subtract(this->position, this->engine->getForwardVector());
-//    }
-
-//     // When we're no longer in front of the parent, update the rotation
-//    float potentialRotation = this->angleToVector(this->engine->position);
-//    this->setRotation({0, potentialRotation, 0});
-
-//    // Now make sure we're close enough
-//    while ( Vector3Length(this->getVectorTowardTarget(*this->engine->getRearAttachmentPoint(), false)) > this->followDistance ) {
-//     this->position = Vector3Add(this->position, this->getForwardVector());
-//    }
-
-
-   
-
-
 
     // Update the train car to be pointing towards and following the TrainComponent assigned to the engine parameter
     // Vector3 directionToParent = this->getVectorTowardTarget(this->engine->position);

--- a/src/classes/TrainCar.cpp
+++ b/src/classes/TrainCar.cpp
@@ -16,7 +16,9 @@ TrainCar::TrainCar(Model model, Texture2D texture, TrainComponent* engine, float
 
     // Initialize the position of the TrainCar based on its "engine"
     Vector3 engineBack = Vector3Negate(this->engine->getForwardVector());
-    this->position = Vector3Add(*this->engine->getRearAttachmentPoint(), Vector3Scale(engineBack, this->followDistance));
+    // TODO: The distance the car initially spawns behind its parent is multiplied by 5 to prevent them from intersecting on spawn
+    // Come up with a cleaner way to handle this
+    this->position = Vector3Add(*this->engine->getRearAttachmentPoint(), Vector3Scale(engineBack, this->followDistance * 5));
 }
 
 /**

--- a/src/classes/TrainCar.cpp
+++ b/src/classes/TrainCar.cpp
@@ -16,7 +16,16 @@ TrainCar::TrainCar(Model model, Texture2D texture, TrainComponent* engine, float
 
     // Initialize the position of the TrainCar based on its "engine"
     Vector3 engineBack = Vector3Negate(this->engine->getForwardVector());
-    this->position = Vector3Add(this->engine->position, Vector3Scale(engineBack, this->followDistance));
+    this->position = Vector3Add(*this->engine->getRearAttachmentPoint(), Vector3Scale(engineBack, this->followDistance));
+}
+
+// https://gamedev.stackexchange.com/a/18998
+bool isInFront(Vector3* point, Vector3* planeOrigin, Vector3 planeForward)
+{
+    double product = (point->x - planeOrigin->x) * planeForward.x
+                     + (point->y - planeOrigin->y) * planeForward.y
+                     + (point->z - planeOrigin->z) * planeForward.z;
+    return (product > 0.f);
 }
 
 /**
@@ -24,12 +33,53 @@ TrainCar::TrainCar(Model model, Texture2D texture, TrainComponent* engine, float
  * @param deltaTime Time in seconds for last frame drawn
 */
 void TrainCar::update(float deltaTime) {
+    this->rearAttachmentPoint = Vector3Subtract(this->position, Vector3Scale(this->getForwardVector(), 2.f));
+    // Thinking up a new way of handling the rotation/position update
+    // Current solution works but allows TrainEngine to rotate freely without impacting cars behind it
+
+    /**
+     * Proposed new solution:
+     * 1. Calculate the rear anchor point of parent
+     * 2. Rotate self to face that rear anchor point
+     * 3. New position should be calculated based on new rotation + followDistance
+     * 4. Define a plane based on rear anchor point + parent forward vector
+     * 5. If my position is positive on that plane;
+     *  5a. Push me in the opposite direction of my parent's forward vector
+     *  5b. Repeat steps 2-5 until 5 is false
+     * 6. New position found
+    */ 
+
+   // Get rear attachment point of parent
+   Vector3* parentAnchor = this->engine->getRearAttachmentPoint();
+
+   // Calculate what my rotation would need to be to face that
+//    float potentialRotation = this->angleToVector(this->engine->position);
+
+   // While I am in the positive of a plane described by my parent's forward vector and anchor point, push me back
+//    while (isInFront(&this->position, parentAnchor, this->engine->getForwardVector())) {
+//     this->position = Vector3Subtract(this->position, this->engine->getForwardVector());
+//    }
+
+//     // When we're no longer in front of the parent, update the rotation
+//    float potentialRotation = this->angleToVector(this->engine->position);
+//    this->setRotation({0, potentialRotation, 0});
+
+//    // Now make sure we're close enough
+//    while ( Vector3Length(this->getVectorTowardTarget(*this->engine->getRearAttachmentPoint(), false)) > this->followDistance ) {
+//     this->position = Vector3Add(this->position, this->getForwardVector());
+//    }
+
+
+   
+
+
+
     // Update the train car to be pointing towards and following the TrainComponent assigned to the engine parameter
-    Vector3 pulledDirection = this->getVectorTowardTarget(this->engine->position);
-    Vector3 invertedPulledDirection = Vector3Negate(pulledDirection);
-    Vector3 scaledInvertedPulledDirection = Vector3Scale(invertedPulledDirection, this->followDistance);
-    this->position = Vector3Add(this->engine->position, scaledInvertedPulledDirection);
-    this->setRotation({0, this->angleToVector(this->engine->position), 0});
+    // Vector3 directionToParent = this->getVectorTowardTarget(this->engine->position);
+    Vector3 directionToParent = this->getVectorTowardTarget(*parentAnchor);
+    Vector3 scaledInvertedPulledDirection = Vector3Scale(Vector3Negate(directionToParent), this->followDistance);
+    this->position = Vector3Add(*parentAnchor, scaledInvertedPulledDirection);
+    this->setRotation({0, this->angleToVector(*parentAnchor), 0});
 
     // Calculate how long is left until this car can shoot again
     if (!this->canShoot) {
@@ -44,6 +94,8 @@ void TrainCar::update(float deltaTime) {
 
     Actor::update();
 }
+
+
 
 int TrainCar::shoot() {
     this->canShoot = false;

--- a/src/classes/TrainComponent.cpp
+++ b/src/classes/TrainComponent.cpp
@@ -3,7 +3,10 @@
 TrainComponent::TrainComponent() : Actor() {}
 
 TrainComponent::TrainComponent(Vector3 position, Model model, Texture2D texture, Model projectileModel, Texture2D projectileTexture)
-    : Actor(position, model, texture), projectileModel(projectileModel), projectileTexture(projectileTexture) {}
+    : Actor(position, model, texture), projectileModel(projectileModel), projectileTexture(projectileTexture) {
+        // TODO: This is WIP
+        this->rearAttachmentPoint = this->position;
+    }
 
 Vector3* TrainComponent::getRearAttachmentPoint() {
     return &this->rearAttachmentPoint;

--- a/src/classes/TrainComponent.cpp
+++ b/src/classes/TrainComponent.cpp
@@ -5,7 +5,7 @@ TrainComponent::TrainComponent() : Actor() {}
 TrainComponent::TrainComponent(Vector3 position, Model model, Texture2D texture, Model projectileModel, Texture2D projectileTexture)
     : Actor(position, model, texture), projectileModel(projectileModel), projectileTexture(projectileTexture) {
         // TODO: This is WIP
-        this->rearAttachmentPoint = this->position;
+        this->rearAttachmentPoint = Vector3Subtract(this->position, Vector3Scale(this->getForwardVector(), 2.f));
     }
 
 Vector3* TrainComponent::getRearAttachmentPoint() {

--- a/src/classes/TrainComponent.cpp
+++ b/src/classes/TrainComponent.cpp
@@ -4,3 +4,7 @@ TrainComponent::TrainComponent() : Actor() {}
 
 TrainComponent::TrainComponent(Vector3 position, Model model, Texture2D texture, Model projectileModel, Texture2D projectileTexture)
     : Actor(position, model, texture), projectileModel(projectileModel), projectileTexture(projectileTexture) {}
+
+Vector3* TrainComponent::getRearAttachmentPoint() {
+    return this->rearAttachmentPoint;
+}

--- a/src/classes/TrainComponent.cpp
+++ b/src/classes/TrainComponent.cpp
@@ -3,10 +3,7 @@
 TrainComponent::TrainComponent() : Actor() {}
 
 TrainComponent::TrainComponent(Vector3 position, Model model, Texture2D texture, Model projectileModel, Texture2D projectileTexture)
-    : Actor(position, model, texture), projectileModel(projectileModel), projectileTexture(projectileTexture) {
-        // TODO: This is WIP
-        this->rearAttachmentPoint = Vector3Subtract(this->position, Vector3Scale(this->getForwardVector(), 2.f));
-    }
+    : Actor(position, model, texture), projectileModel(projectileModel), projectileTexture(projectileTexture) { }
 
 Vector3* TrainComponent::getRearAttachmentPoint() {
     return &this->rearAttachmentPoint;

--- a/src/classes/TrainComponent.cpp
+++ b/src/classes/TrainComponent.cpp
@@ -6,5 +6,5 @@ TrainComponent::TrainComponent(Vector3 position, Model model, Texture2D texture,
     : Actor(position, model, texture), projectileModel(projectileModel), projectileTexture(projectileTexture) {}
 
 Vector3* TrainComponent::getRearAttachmentPoint() {
-    return this->rearAttachmentPoint;
+    return &this->rearAttachmentPoint;
 }

--- a/src/classes/TrainComponent.h
+++ b/src/classes/TrainComponent.h
@@ -4,6 +4,9 @@
 #include "src/interfaces/IUpdatable.h"
 
 class TrainComponent : public Actor, public IUpdatable {
+private:
+    Vector3 rearAttachmentPoint;
+
 public:
     /**
      * Default constructor
@@ -24,4 +27,9 @@ public:
      * @param projectileTexture     Texture to apply to the projectiles
     */
     TrainComponent(Vector3 position, Model model, Texture2D texture, Model projectileModel, Texture2D projectiletexture); // TODO: This should accept pointers to assets
+
+    /**
+     * Returns the value of the rearAttachmentPoint member
+    */
+    Vector3* getRearAttachmentPoint();
  };

--- a/src/classes/TrainComponent.h
+++ b/src/classes/TrainComponent.h
@@ -4,7 +4,7 @@
 #include "src/interfaces/IUpdatable.h"
 
 class TrainComponent : public Actor, public IUpdatable {
-private:
+protected:
     Vector3 rearAttachmentPoint;
 
 public:

--- a/src/classes/TrainEngine.cpp
+++ b/src/classes/TrainEngine.cpp
@@ -1,5 +1,4 @@
 #include "TrainEngine.h"
-#include <iostream>
 
 /**
  * Default TrainEngine constructor
@@ -34,9 +33,6 @@ float TrainEngine::getSpeed() {
 
 void TrainEngine::update(float deltaTime) {
     this->rearAttachmentPoint = Vector3Subtract(this->position, Vector3Scale(this->getForwardVector(), 8.f));
-
-    std::cout << "Position: " << this->position.x << ", " << this->position.z << std::endl;
-    std::cout << "Anchor: " << this->rearAttachmentPoint.x << ", " << this->rearAttachmentPoint.z << std::endl;
     
     // Update the audio stream for the engine sound
     UpdateMusicStream(this->engineSound);

--- a/src/classes/TrainEngine.cpp
+++ b/src/classes/TrainEngine.cpp
@@ -1,4 +1,5 @@
 #include "TrainEngine.h"
+#include <iostream>
 
 /**
  * Default TrainEngine constructor
@@ -32,6 +33,10 @@ float TrainEngine::getSpeed() {
 }
 
 void TrainEngine::update(float deltaTime) {
+    this->rearAttachmentPoint = Vector3Subtract(this->position, Vector3Scale(this->getForwardVector(), 8.f));
+
+    std::cout << "Position: " << this->position.x << ", " << this->position.z << std::endl;
+    std::cout << "Anchor: " << this->rearAttachmentPoint.x << ", " << this->rearAttachmentPoint.z << std::endl;
     
     // Update the audio stream for the engine sound
     UpdateMusicStream(this->engineSound);


### PR DESCRIPTION
This PR makes train cars respond to the rotation of the train car in front of them. Previously rotation/position was based solely on the position (origin) of the train component ahead, so rotating the parent had no impact on the cars behind it.

This makes the train behave a bit nicer, but it still needs some work. Train components don't collide with one another so by rotating enough while stationary, the train can still intersect with itself